### PR TITLE
Set default theme for new users

### DIFF
--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -76,7 +76,7 @@ export default {
       defaultSettings: {
         language: 'en',
         theme: {
-          global: 'theme-default',
+          global: 'default',
         },
       },
     };
@@ -108,7 +108,7 @@ export default {
 
     if (this.platform && !this.localSettings[this.platform.code]) {
       this.localSettings[this.platform.code] = {
-        theme: 'theme-default',
+        theme: 'default',
       };
     }
   },


### PR DESCRIPTION
When first loading the new version that has different themes, or joining the website with a new account, the theme setting was showing a blank dropdown.
The website's theme was set to `theme-default` but the dropdown didn't show anything.