### PR TITLE
Fix app-icon links and meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,23 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, minimal-ui">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,500,700,400italic|Material+Icons">
-    <link rel="apple-touch-icon" sizes="57x57" href="static/icons/apple-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="static/icons/apple-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="static/icons/apple-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="static/icons/apple-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="static/icons/apple-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="static/icons/apple-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="static/icons/apple-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="static/icons/apple-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="static/icons/apple-icon-180x180.png">
-    <link rel="icon" type="image/png" sizes="192x192"  href="static/icons/android-icon-192x192.png">
+    <link rel="apple-touch-icon" href="static/icons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192"  href="static/icons/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="32x32" href="static/icons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="static/icons/icon-96x96.png">
     <link rel="icon" type="image/png" sizes="16x16" href="static/icons/favicon-16x16.png">
+    <link rel="shortcut icon" href="static/icons/favicon.ico">
     <link rel="manifest" href="static/manifest.json">
+    <link rel="mask-icon" href="static/icons/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#222226">
-    <meta name="msapplication-TileImage" content="static/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="static/icons/mstile-150x150.png">
+    <meta name="msapplication-config" content="static/icons/browserconfig.xml">
     <meta name="theme-color" content="#222226">
+    <meta name="apple-mobile-web-app-title" content="Gamebrary">
     <meta name="description" content="Open source tool to organize video game collections.">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
The `index.html` had a number of links and meta for non-existing icons.

I cleaned it up a bit and linked to the correct and existing icons. This way the homescreen and tile icons will appear correctly.