### PR TITLE
Display empty stars for a better UX

### DIFF
--- a/src/components/GameDetail/GameRating.vue
+++ b/src/components/GameDetail/GameRating.vue
@@ -2,7 +2,8 @@
   <div :class="['game-rating', { small }]">
     <span v-for="n in 5" :key="`star-${n}`">
       <i v-if="(roundedRating - n) + 1 >= 1" class="fas fa-star" />
-      <i v-if="(roundedRating - n) + 1 === .5" class="fas fa-star-half" />
+      <i v-if="(roundedRating - n) + 1 === .5" class="fas fa-star-half-alt" />
+      <i v-if="(roundedRating - n) + 1 <= 0" class="far fa-star" />
     </span>
   </div>
 </template>


### PR DESCRIPTION
I wanted to add this commit to a bigger branch where I would add custom rating and display that alongside the IGDB rating.

But with #152 not working as intended I'm fairly certain I'm gonna fall into the same problem with this feature, so I'll wait until there's a solution.