### PR TITLE
Set scroll snapping to X instead of Y

### DIFF
--- a/src/pages/GameBoard.vue
+++ b/src/pages/GameBoard.vue
@@ -149,7 +149,7 @@ export default {
   display: flex;
 
   @media($small) {
-    scroll-snap-type: y mandatory;
+    scroll-snap-type: x mandatory;
   }
 }
 


### PR DESCRIPTION
I noticed that the scroll snapping didn't work on mobile.

That's because I set it to Y. I should've set it to X. Vertically. It's a bit odd that it worked as I expected it to work in Firefox's and Chrome's dev tool's device/responsive tools.