### PR TITLE
[#160] Persistent saving of list settings

### DIFF
--- a/src/components/Lists/ListSettingsModal.vue
+++ b/src/components/Lists/ListSettingsModal.vue
@@ -249,14 +249,16 @@ export default {
 
       gameLists[this.platform.code][this.listIndex] = this.localList;
 
-      this.$store.dispatch('SAVE_LIST', gameLists)
-        .then(() => {
-          this.$bus.$emit('TOAST', { message: 'List saved' });
-        })
-        .catch(() => {
-          this.$bus.$emit('TOAST', { message: 'Authentication error', type: 'error' });
-          this.$router.push({ name: 'sessionExpired' });
-        });
+      setTimeout(() => {
+        this.$store.dispatch('SAVE_LIST', gameLists)
+          .then(() => {
+            this.$bus.$emit('TOAST', { message: 'List saved' });
+          })
+          .catch(() => {
+            this.$bus.$emit('TOAST', { message: 'Authentication error', type: 'error' });
+            this.$router.push({ name: 'sessionExpired' });
+          });
+      }, 500);
     },
 
     async moveList(from, to) {


### PR DESCRIPTION
This is a fix for #160.

I don't know if this is the ideal way to fix this issue, but it's the only way I found to fix it without calling the `save()` function twice.