### PR TITLE
Increase drag and drop area

### DIFF
--- a/src/components/GameBoard/ListAddModal.vue
+++ b/src/components/GameBoard/ListAddModal.vue
@@ -2,6 +2,7 @@
   <modal
     ref="listAddModal"
     :title="title"
+    class="list-add-modal"
     @open="open"
   >
     <button
@@ -151,6 +152,16 @@ export default {
 
   .add-list-button {
     margin-right: $gp;
+  }
+
+  @media($small) {
+    .list-add-modal {
+      min-width: calc(100vw - #{$gp});
+
+      .add-list-button {
+        margin-right: 0;
+      }
+    }
   }
 
   small {

--- a/src/components/GameBoard/ListAddModal.vue
+++ b/src/components/GameBoard/ListAddModal.vue
@@ -154,16 +154,6 @@ export default {
     margin-right: $gp;
   }
 
-  @media($small) {
-    .list-add-modal {
-      min-width: calc(100vw - #{$gp});
-
-      .add-list-button {
-        margin-right: 0;
-      }
-    }
-  }
-
   small {
     color: var(--warning-color);
     margin: 0 $gp;

--- a/src/components/GameCards/GameCardCompact.vue
+++ b/src/components/GameCards/GameCardCompact.vue
@@ -148,8 +148,9 @@ export default {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;
-      right: $gp / 3;
-      top: $gp / 3;
+      padding: $gp / 3;
+      right: 0;
+      top: 0;
 
       &:hover {
         color: #a5a2a2;

--- a/src/components/GameCards/GameCardCompact.vue
+++ b/src/components/GameCards/GameCardCompact.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <div v-if="gameId && games[gameId]" :class="[gameCardClass, 'game-drag-handle']">
+  <div v-if="gameId && games[gameId]" :class="gameCardClass">
     <img
       :src="coverUrl"
       :alt="game.name"
@@ -99,7 +99,11 @@ export default {
     &.card-placeholder {
       background: #e5e5e5;
       outline: 1px dashed #a5a2a2;
-      opacity: 0.6;
+      opacity: 0.3;
+
+      img {
+        filter: grayscale(1);
+      }
 
       .game-card-options {
         display: none;
@@ -111,6 +115,7 @@ export default {
       width: 100%;
       display: flex;
       flex-direction: column;
+      align-items: flex-start;
 
       .game-tags {
         display: flex;

--- a/src/components/GameCards/GameCardCompact.vue
+++ b/src/components/GameCards/GameCardCompact.vue
@@ -1,9 +1,8 @@
 <template lang="html">
-  <div v-if="gameId && games[gameId]" :class="gameCardClass">
+  <div v-if="gameId && games[gameId]" :class="[gameCardClass, 'game-drag-handle']">
     <img
       :src="coverUrl"
       :alt="game.name"
-      class="game-drag-handle"
       @click="openDetails"
     >
 
@@ -11,6 +10,7 @@
       <a
         v-if="list.view !== 'covers'"
         @click="openDetails"
+        class="drag-filter"
         v-text="game.name"
       />
 
@@ -20,6 +20,7 @@
         v-if="showGameRatings"
         :rating="game.rating"
         small
+        class="drag-filter"
         @click.native="openDetails"
       />
 
@@ -27,17 +28,18 @@
         v-if="gameProgress"
         small
         :progress="gameProgress"
+        class="drag-filter"
         @click.native="openDetails"
       />
 
       <i
         v-if="note"
         :title="note"
-        class="fas fa-sticky-note note"
+        class="fas fa-sticky-note note drag-filter"
         @click="openDetails"
       />
 
-      <div v-if="hasTags" class="game-tags">
+      <div v-if="hasTags" class="game-tags drag-filter">
         <div
           v-for="({ games, hex, tagTextColor }, name) in tags"
           v-if="games.includes(game.id)"
@@ -149,9 +151,8 @@ export default {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;
-      padding: $gp / 3;
-      right: 0;
-      top: 0;
+      right: $gp / 3;
+      top: $gp / 3;
 
       &:hover {
         color: #a5a2a2;

--- a/src/components/GameCards/GameCardCompact.vue
+++ b/src/components/GameCards/GameCardCompact.vue
@@ -3,6 +3,7 @@
     <img
       :src="coverUrl"
       :alt="game.name"
+      class="game-drag-handle"
       @click="openDetails"
     >
 
@@ -13,7 +14,7 @@
         v-text="game.name"
       />
 
-      <i class="fas fa-grip-vertical game-drag-handle" />
+      <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
       <game-rating
         v-if="showGameRatings"
@@ -144,7 +145,7 @@ export default {
       }
     }
 
-    .game-drag-handle {
+    .draggable-icon {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;

--- a/src/components/GameCards/GameCardDefault.vue
+++ b/src/components/GameCards/GameCardDefault.vue
@@ -4,6 +4,7 @@
     <img
       :src="coverUrl"
       :alt="game.name"
+      class="game-drag-handle"
       @click="openDetails"
     >
 
@@ -14,7 +15,7 @@
         @click="openDetails"
       />
 
-      <i class="fas fa-grip-vertical game-drag-handle" />
+      <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
       <game-progress
         v-if="gameProgress"
@@ -147,7 +148,7 @@ export default {
       }
     }
 
-    .game-drag-handle {
+    .draggable-icon {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;

--- a/src/components/GameCards/GameCardDefault.vue
+++ b/src/components/GameCards/GameCardDefault.vue
@@ -1,10 +1,9 @@
 <!-- TODO: abstract styles, only add card specific styles in each component -->
 <template lang="html">
-  <div v-if="gameId && games[gameId]" :class="gameCardClass">
+  <div v-if="gameId && games[gameId]" :class="[gameCardClass, 'game-drag-handle']">
     <img
       :src="coverUrl"
       :alt="game.name"
-      class="game-drag-handle"
       @click="openDetails"
     >
 
@@ -12,6 +11,7 @@
       <a
         v-if="list.view !== 'covers'"
         v-text="game.name"
+        class="drag-filter"
         @click="openDetails"
       />
 
@@ -21,6 +21,7 @@
         v-if="gameProgress"
         small
         :progress="gameProgress"
+        class="drag-filter"
         @click.native="openDetails"
       />
 
@@ -28,34 +29,34 @@
         v-if="showGameRatings"
         :rating="game.rating"
         small
+        class="drag-filter"
         @click.native="openDetails"
       />
 
       <i
         v-if="note"
         :title="note"
-        class="fas fa-sticky-note note"
+        class="fas fa-sticky-note note drag-filter"
         @click="openDetails"
       />
 
-      <div v-if="hasTags" class="game-tags">
-
-      <div
-        v-for="({ games, hex, tagTextColor }, name) in tags"
-        v-if="games.includes(game.id)"
-        :key="name"
-      >
-        <tag
+      <div v-if="hasTags" class="game-tags drag-filter">
+        <div
+          v-for="({ games, hex, tagTextColor }, name) in tags"
           v-if="games.includes(game.id)"
-          :label="name"
-          :hex="hex"
-          :text-hex="tagTextColor"
-          readonly
-          @action="openTags"
-        />
+          :key="name"
+        >
+          <tag
+            v-if="games.includes(game.id)"
+            :label="name"
+            :hex="hex"
+            :text-hex="tagTextColor"
+            readonly
+            @action="openTags"
+          />
+      </div>
     </div>
   </div>
-</div>
 </div>
 </template>
 
@@ -152,9 +153,8 @@ export default {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;
-      padding: $gp / 3;
-      right: 0;
-      top: 0;
+      right: $gp / 3;
+      top: $gp / 3;
 
       &:hover {
         color: #a5a2a2;

--- a/src/components/GameCards/GameCardDefault.vue
+++ b/src/components/GameCards/GameCardDefault.vue
@@ -151,8 +151,9 @@ export default {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;
-      right: $gp / 3;
-      top: $gp / 3;
+      padding: $gp / 3;
+      right: 0;
+      top: 0;
 
       &:hover {
         color: #a5a2a2;

--- a/src/components/GameCards/GameCardDefault.vue
+++ b/src/components/GameCards/GameCardDefault.vue
@@ -1,6 +1,6 @@
 <!-- TODO: abstract styles, only add card specific styles in each component -->
 <template lang="html">
-  <div v-if="gameId && games[gameId]" :class="[gameCardClass, 'game-drag-handle']">
+  <div v-if="gameId && games[gameId]" :class="gameCardClass">
     <img
       :src="coverUrl"
       :alt="game.name"
@@ -92,8 +92,13 @@ export default {
     overflow: hidden;
 
     &.card-placeholder {
-      background: var(--game-card-background);
+      background: #e5e5e5;
+      outline: 1px dashed #a5a2a2;
       opacity: 0.3;
+
+      img {
+        filter: grayscale(1);
+      }
 
       .game-card-options {
         display: none;
@@ -113,6 +118,7 @@ export default {
       width: 100%;
       display: flex;
       flex-direction: column;
+      align-items: flex-start;
 
       .game-tags {
         display: flex;
@@ -131,6 +137,7 @@ export default {
         right: $gp / 4;
       }
 
+      .game-progress,
       .game-rating, a {
         display: inline-flex;
         font-weight: bold;

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <div v-if="gameId && games[gameId]" :class="[gameCardClass, 'game-drag-handle']">
+  <div v-if="gameId && games[gameId]" :class="gameCardClass">
     <img
       :src="coverUrl"
       :alt="game.name"
@@ -98,8 +98,13 @@ export default {
   cursor: pointer;
 
   &.card-placeholder {
-    background: var(--game-card-background);
+    background: #e5e5e5;
+    outline: 1px dashed #a5a2a2;
     opacity: 0.3;
+
+    img {
+      filter: grayscale(1);
+    }
 
     .game-card-options {
       display: none;
@@ -134,6 +139,7 @@ export default {
     border-bottom-right-radius: var(--border-radius);
     flex-direction: column;
     background: var(--game-card-background);
+    align-items: flex-start;
 
     .game-tags {
       display: flex;

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -195,8 +195,9 @@ export default {
     @include drag-cursor;
     position: absolute;
     color: #e5e5e5;
-    right: $gp / 3;
-    top: $gp / 3;
+    padding: $gp / 3;
+    right: 0;
+    top: 0;
 
     &:hover {
       color: #a5a2a2;

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -15,7 +15,7 @@
 
     <i
       v-if="!showGameInfo"
-      class="fas fa-grip-vertical game-drag-handle"
+      class="fas fa-grip-vertical draggable-icon game-drag-handle"
     />
 
     <div

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -3,6 +3,7 @@
     <img
       :src="coverUrl"
       :alt="game.name"
+      class="game-drag-handle"
       @click="openDetails"
     >
 
@@ -48,7 +49,7 @@
           @click="openDetails"
         />
 
-        <i class="fas fa-grip-vertical game-drag-handle" />
+        <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
         <div v-if="hasTags" class="game-tags">
           <tag
@@ -191,7 +192,7 @@ export default {
     }
   }
 
-  .game-drag-handle {
+  .draggable-icon {
     @include drag-cursor;
     position: absolute;
     color: #e5e5e5;

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -1,9 +1,8 @@
 <template lang="html">
-  <div v-if="gameId && games[gameId]" :class="gameCardClass">
+  <div v-if="gameId && games[gameId]" :class="[gameCardClass, 'game-drag-handle']">
     <img
       :src="coverUrl"
       :alt="game.name"
-      class="game-drag-handle"
       @click="openDetails"
     >
 
@@ -25,6 +24,7 @@
     >
         <a
           v-text="game.name"
+          class="drag-filter"
           @click="openDetails"
         />
 
@@ -32,6 +32,7 @@
           v-if="showGameRatings"
           :rating="game.rating"
           small
+          class="drag-filter"
           @click.native="openDetails"
         />
 
@@ -39,19 +40,20 @@
           v-if="gameProgress"
           small
           :progress="gameProgress"
+          class="drag-filter"
           @click.native="openDetails"
         />
 
         <i
           v-if="note"
           :title="note"
-          class="fas fa-sticky-note note"
+          class="fas fa-sticky-note note drag-filter"
           @click="openDetails"
         />
 
         <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
-        <div v-if="hasTags" class="game-tags">
+        <div v-if="hasTags" class="game-tags drag-filter">
           <tag
             v-for="({ games, hex, tagTextColor }, name) in tags"
             v-if="games.includes(game.id)"
@@ -196,9 +198,8 @@ export default {
     @include drag-cursor;
     position: absolute;
     color: #e5e5e5;
-    padding: $gp / 3;
-    right: 0;
-    top: 0;
+    right: $gp / 3;
+    top: $gp / 3;
 
     &:hover {
       color: #a5a2a2;

--- a/src/components/GameCards/GameCardText.vue
+++ b/src/components/GameCards/GameCardText.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <div v-if="gameId && games[gameId]" :class="[gameCardClass, 'game-drag-handle']">
+  <div v-if="gameId && games[gameId]" :class="gameCardClass">
     <div class="game-info">
       <a v-text="game.name" class="drag-filter" @click="openDetails"/>
       <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
@@ -83,7 +83,7 @@ export default {
     &.card-placeholder {
       background: #e5e5e5;
       outline: 1px dashed #a5a2a2;
-      opacity: 0.6;
+      opacity: 0.3;
 
       .game-card-options {
         display: none;

--- a/src/components/GameCards/GameCardText.vue
+++ b/src/components/GameCards/GameCardText.vue
@@ -1,13 +1,14 @@
 <template lang="html">
-  <div v-if="gameId && games[gameId]" :class="gameCardClass">
+  <div v-if="gameId && games[gameId]" :class="[gameCardClass, 'game-drag-handle']">
     <div class="game-info">
-      <a v-text="game.name" @click="openDetails"/>
+      <a v-text="game.name" class="drag-filter" @click="openDetails"/>
       <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
       <game-rating
         v-if="showGameRatings && list.view !== 'covers'"
         :rating="game.rating"
         small
+        class="drag-filter"
         @click.native="openDetails"
       />
 
@@ -15,19 +16,20 @@
         v-if="gameProgress"
         small
         :progress="gameProgress"
+        class="drag-filter"
         @click.native="openDetails"
       />
 
       <i
         v-if="note"
         :title="note"
-        class="fas fa-sticky-note note"
+        class="fas fa-sticky-note note drag-filter"
         @click="openDetails"
       />
 
       <div
         v-if="hasTags"
-        class="game-tags"
+        class="game-tags drag-filter"
 >
         <div
           v-for="({ games, hex, tagTextColor }, name) in tags"
@@ -93,6 +95,7 @@ export default {
       width: 100%;
       display: flex;
       flex-direction: column;
+      align-items: flex-start;
 
       .game-tags {
         display: flex;
@@ -133,9 +136,8 @@ export default {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;
-      padding: $gp / 3;
-      right: 0;
-      top: 0;
+      right: $gp / 3;
+      top: $gp / 3;
 
       &:hover {
         color: #a5a2a2;

--- a/src/components/GameCards/GameCardText.vue
+++ b/src/components/GameCards/GameCardText.vue
@@ -2,7 +2,7 @@
   <div v-if="gameId && games[gameId]" :class="gameCardClass">
     <div class="game-info">
       <a v-text="game.name" @click="openDetails"/>
-      <i class="fas fa-grip-vertical game-drag-handle" />
+      <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
       <game-rating
         v-if="showGameRatings && list.view !== 'covers'"
@@ -129,7 +129,7 @@ export default {
       }
     }
 
-    .game-drag-handle {
+    .draggable-icon {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;

--- a/src/components/GameCards/GameCardText.vue
+++ b/src/components/GameCards/GameCardText.vue
@@ -133,8 +133,9 @@ export default {
       @include drag-cursor;
       position: absolute;
       color: #e5e5e5;
-      right: $gp / 3;
-      top: $gp / 3;
+      padding: $gp / 3;
+      right: 0;
+      top: 0;
 
       &:hover {
         color: #a5a2a2;

--- a/src/components/GameDetail/GameProgress.vue
+++ b/src/components/GameDetail/GameProgress.vue
@@ -70,6 +70,7 @@ export default {
   .game-progress {
     display: grid;
     width: 140px;
+    align-self: stretch;
     align-items: center;
     justify-items: center;
     margin: $gp / 2 0;
@@ -132,6 +133,18 @@ export default {
         &::after {
           width: var(--progress-width);
           line-height: 1;
+        }
+      }
+    }
+
+    .card-placeholder & {
+      .progress-bar-label {
+        &.not-progressed {
+          background: #a5a2a2;
+        }
+
+        &.progressed {
+          background: #777777;
         }
       }
     }

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -287,6 +287,12 @@ export default {
     dragStart({ item }) {
       this.$store.commit('SET_DRAGGING_STATUS', true);
       this.draggingId = item.id;
+
+      this.$nextTick(() => {
+        if (window.innerWidth <= 780) {
+          window.navigator.vibrate([150, 30, 150]);
+        }
+      });
     },
 
     dragEnd() {

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -108,11 +108,10 @@ export default {
       masonry: null,
       gameDraggableOptions: {
         handle: '.game-card',
-        forceFallback: true,
-        fallbackClass: 'card-placeholder',
-        fallbackOnBody: true,
+        ghostClass: 'card-placeholder',
         filter: '.drag-filter',
-        fallbackTolerance: 50,
+        delay: 100,
+        delayOnTouchOnly: true,
         animation: 500,
         group: {
           name: 'games',
@@ -288,31 +287,11 @@ export default {
     dragStart({ item }) {
       this.$store.commit('SET_DRAGGING_STATUS', true);
       this.draggingId = item.id;
-
-      this.$nextTick(() => {
-        if (window.innerWidth <= 780) {
-          const gameBoard = document.querySelector('.game-board');
-          const windowWidth = document.documentElement.clientWidth;
-          const listWidth = item.closest('.list.dragging').clientWidth;
-
-          gameBoard.scrollTo({ left: gameBoard.scrollLeft - ((windowWidth - listWidth) / 2), behavior: 'smooth' });
-        }
-      });
     },
 
     dragEnd() {
       this.$store.commit('SET_DRAGGING_STATUS', false);
       this.$emit('dragEnd');
-
-      this.$nextTick(() => {
-        if (window.innerWidth <= 780) {
-          const gameBoard = document.querySelector('.game-board');
-          const windowWidth = document.documentElement.clientWidth;
-          const listWidth = document.querySelector('.list').clientWidth;
-
-          gameBoard.scrollTo({ left: gameBoard.scrollLeft + ((windowWidth - listWidth) / 2), behavior: 'smooth' });
-        }
-      });
     },
   },
 };

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -109,6 +109,7 @@ export default {
       gameDraggableOptions: {
         handle: '.game-drag-handle',
         ghostClass: 'card-placeholder',
+        filter: '.drag-filter',
         animation: 500,
         group: {
           name: 'games',
@@ -304,7 +305,6 @@ export default {
     width: 300px;
     background: var(--list-background);
     border-radius: var(--border-radius);
-    overflow: hidden;
     margin-right: $gp;
     max-height: calc(100vh - 100px);
 

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -285,11 +285,31 @@ export default {
     dragStart({ item }) {
       this.$store.commit('SET_DRAGGING_STATUS', true);
       this.draggingId = item.id;
+
+      this.$nextTick(() => {
+        if (window.innerWidth <= 780) {
+          const gameBoard = document.querySelector('.game-board');
+          const windowWidth = document.documentElement.clientWidth;
+          const listWidth = item.closest('.list.dragging').clientWidth;
+
+          gameBoard.scrollTo({ left: gameBoard.scrollLeft - ((windowWidth - listWidth) / 2), behavior: 'smooth' });
+        }
+      });
     },
 
     dragEnd() {
       this.$store.commit('SET_DRAGGING_STATUS', false);
       this.$emit('dragEnd');
+
+      this.$nextTick(() => {
+        if (window.innerWidth <= 780) {
+          const gameBoard = document.querySelector('.game-board');
+          const windowWidth = document.documentElement.clientWidth;
+          const listWidth = document.querySelector('.list').clientWidth;
+
+          gameBoard.scrollTo({ left: gameBoard.scrollLeft + ((windowWidth - listWidth) / 2), behavior: 'smooth' });
+        }
+      });
     },
   },
 };

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -290,7 +290,7 @@ export default {
 
       this.$nextTick(() => {
         if (window.innerWidth <= 780) {
-          window.navigator.vibrate([150, 30, 150]);
+          window.navigator.vibrate([100]);
         }
       });
     },

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -311,7 +311,7 @@ export default {
     @media($small) {
       &:not(.dragging) {
         .games {
-          scroll-snap-type: y mandatory;
+          scroll-snap-type: x mandatory;
           scroll-padding: $gp / 2;
 
           .game-card {

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -311,6 +311,9 @@ export default {
     max-height: calc(100vh - 100px);
 
     @media($small) {
+      max-height: calc(100vh - 80px);
+      min-height: calc(100vh - 80px);
+
       &:not(.dragging) {
         .games {
           scroll-snap-type: x mandatory;

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -107,8 +107,10 @@ export default {
     return {
       masonry: null,
       gameDraggableOptions: {
-        handle: '.game-drag-handle',
-        ghostClass: 'card-placeholder',
+        handle: '.game-card',
+        forceFallback: true,
+        fallbackClass: 'card-placeholder',
+        fallbackOnBody: true,
         filter: '.drag-filter',
         animation: 500,
         group: {

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -112,6 +112,7 @@ export default {
         fallbackClass: 'card-placeholder',
         fallbackOnBody: true,
         filter: '.drag-filter',
+        fallbackTolerance: 50,
         animation: 500,
         group: {
           name: 'games',

--- a/src/pages/GameBoard.vue
+++ b/src/pages/GameBoard.vue
@@ -145,21 +145,26 @@ export default {
   display: flex;
 
   @media($small) {
-    .bottom & {
-      padding: $gp $gp 0;
-    }
-  }
+    transform: scale(.9);
+    transition: all 0.25s linear;
+    width: calc(100% / 0.9);
+    transform-origin: top center;
 
-  @media($small) {
     &:not(.dragging) {
       scroll-snap-type: mandatory;
       scroll-snap-points-x: repeat(300px);
       scroll-snap-type: x mandatory;
       scroll-padding: $gp;
+      transform: none;
+      width: 100%;
 
       .list {
         scroll-snap-align: start;
       }
+    }
+
+    .bottom & {
+      padding: $gp $gp 0;
     }
   }
 }

--- a/src/pages/GameBoard.vue
+++ b/src/pages/GameBoard.vue
@@ -163,6 +163,13 @@ export default {
       .list {
         scroll-snap-align: start;
       }
+
+      .list-add-modal {
+        scroll-snap-type: mandatory;
+        scroll-snap-points-x: repeat(300px);
+        scroll-snap-type: x mandatory;
+        scroll-snap-align: start;
+      }
     }
 
     .bottom & {

--- a/src/pages/GameBoard.vue
+++ b/src/pages/GameBoard.vue
@@ -145,7 +145,7 @@ export default {
   display: flex;
 
   @media($small) {
-    transform: scale(.9);
+    transform: scale(.9) translateX(calc(-100% * 0.05));
     transition: all 0.25s linear;
     width: calc(100% / 0.9);
     height: calc((100vh - 48px) / 0.9);

--- a/src/pages/GameBoard.vue
+++ b/src/pages/GameBoard.vue
@@ -145,20 +145,11 @@ export default {
   display: flex;
 
   @media($small) {
-    transform: scale(.9) translateX(calc(-100% * 0.05));
-    transition: all 0.25s linear;
-    width: calc(100% / 0.9);
-    height: calc((100vh - 48px) / 0.9);
-    transform-origin: top center;
-
     &:not(.dragging) {
       scroll-snap-type: mandatory;
       scroll-snap-points-x: repeat(300px);
       scroll-snap-type: x mandatory;
       scroll-padding: $gp;
-      transform: none;
-      width: 100%;
-      height: calc(100vh - 48px);
 
       .list {
         scroll-snap-align: start;

--- a/src/pages/GameBoard.vue
+++ b/src/pages/GameBoard.vue
@@ -152,14 +152,7 @@ export default {
       scroll-padding: $gp;
 
       .list {
-        scroll-snap-align: start;
-      }
-
-      .list-add-modal {
-        scroll-snap-type: mandatory;
-        scroll-snap-points-x: repeat(300px);
-        scroll-snap-type: x mandatory;
-        scroll-snap-align: start;
+        scroll-snap-align: center;
       }
     }
 

--- a/src/pages/GameBoard.vue
+++ b/src/pages/GameBoard.vue
@@ -148,6 +148,7 @@ export default {
     transform: scale(.9);
     transition: all 0.25s linear;
     width: calc(100% / 0.9);
+    height: calc((100vh - 48px) / 0.9);
     transform-origin: top center;
 
     &:not(.dragging) {
@@ -157,6 +158,7 @@ export default {
       scroll-padding: $gp;
       transform: none;
       width: 100%;
+      height: calc(100vh - 48px);
 
       .list {
         scroll-snap-align: start;


### PR DESCRIPTION
Drag and drop is a bit cumbersome on mobile, because the small little drag icon is too small for fingers to quickly grab. I set the whole game card as drag handle and added some filters for the text and elements that have click events.

I also wanted lists to have the full height of the viewport at all times on mobile, as well as adjusting a couple scroll issues (see ba4e4fe's `List.vue` and ba02805's `ListAddModal.vue`).

---
I had this whole idea about zooming the game board out (up until 
3a526b8) but I didn't really get it to work on my actual phone, just in my browser's responsive design mode. I capped it, especially so this might still make it into the app before the big 3.0 work is starting.