### PR TITLE
option to hide game info displayed on cover

### DIFF
--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -36,13 +36,9 @@ export default {
     },
 
     gameCardClass() {
-      let badge = '';
-
-      if (this.showGameInfoOnCover) {
-        badge = this.gameProgress === '100'
-          ? 'badge'
-          : '';
-      }
+      const badge = this.showGameInfoOnCover && this.gameProgress === '100'
+        ? 'badge'
+        : '';
 
       return [
         'game-card',

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -24,6 +24,10 @@ export default {
       return this.list && !this.list.hideGameInfo;
     },
 
+    showGameInfoOnCover() {
+      return this.list && !this.list.hideGameInfoOnCover;
+    },
+
     gameProgress() {
       return this.game
         && this.platform
@@ -32,9 +36,13 @@ export default {
     },
 
     gameCardClass() {
-      const badge = this.gameProgress === '100'
-        ? 'badge'
-        : '';
+      let badge = '';
+
+      if (this.showGameInfoOnCover) {
+        badge = this.gameProgress === '100'
+          ? 'badge'
+          : '';
+      }
 
       return [
         'game-card',

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -7,16 +7,13 @@
     >
 
     <game-progress
-      v-if="!showGameInfo && gameProgress"
+      v-if="!showGameInfo && showGameInfoOnCover && gameProgress"
       small
       :progress="gameProgress"
       @click.native="openDetails"
     />
 
-    <i
-      v-if="!showGameInfo"
-      class="fas fa-grip-vertical draggable-icon game-drag-handle"
-    />
+    <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
     <div
       v-if="showGameInfo"

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -235,6 +235,10 @@ export default {
     hideGameInfo() {
       return this.list[this.listIndex].hideGameInfo || false;
     },
+
+    hideGameInfoOnCover() {
+      return this.list[this.listIndex].hideGameInfoOnCover || false;
+    },
   },
 
   watch: {

--- a/src/components/Lists/ListSettingsModal.vue
+++ b/src/components/Lists/ListSettingsModal.vue
@@ -79,12 +79,22 @@
       </section>
 
       <section v-if="localList.view === 'grid'">
-        <h4>Hide game info</h4>
+        <h4>Compact grid view</h4>
 
         <toggle-switch
           id="gameInfo"
           @change="save"
           v-model="localList.hideGameInfo"
+        />
+      </section>
+
+      <section :class="{ disabled: !localList.hideGameInfo }" v-if="localList.view === 'grid'">
+        <h4>Hide game info on top of game covers</h4>
+
+        <toggle-switch
+          id="hideGameInfoOnCover"
+          @change="save"
+          v-model="localList.hideGameInfoOnCover"
         />
       </section>
 


### PR DESCRIPTION
## About
I noticed that some of my recent progression additions intentionally ignored the "hide game info" setting - or at least its spirit - by adding select game info anyway, although on top of the game cover.

This will give users an option to really only display the game cover (and the drag icon) instead of any other silly ideas I have planned (days until release etc).

## Screenshots
![Screenshot 2020-02-11 at 2 17 24 PM](https://user-images.githubusercontent.com/984069/74240107-95057b00-4cd9-11ea-989a-01564c4186b9.png)
![Screenshot 2020-02-11 at 2 17 16 PM](https://user-images.githubusercontent.com/984069/74240117-99ca2f00-4cd9-11ea-9b18-ab50b5251a3f.png)
![Screenshot 2020-02-11 at 2 17 07 PM](https://user-images.githubusercontent.com/984069/74240129-9d5db600-4cd9-11ea-85b9-bcca1d922fa2.png)
