### PR TITLE
[183] Show when an upcoming game is going to be released

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -14,7 +14,7 @@ exports.search = functions.https.onRequest((req, res) => {
 
     const data = `
     search "${search}";
-    fields id,name,slug,rating,name,cover.image_id;
+    fields id,name,slug,rating,release_dates.*,name,cover.image_id;
     limit 50;
     where platforms = (${platform});`
 

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -46,7 +46,7 @@ export default {
         && this.game.release_dates.filter(({ platform }) => this.platform.id === platform)[0].date;
 
       const daysUntilRelease = Math
-        .round((new Date(releaseDate * 1000) - new Date()) / (1000 * 60 * 60 * 24));
+        .ceil((new Date(releaseDate * 1000) - new Date()) / (1000 * 60 * 60 * 24));
 
       if (daysUntilRelease >= 0) {
         return `${daysUntilRelease}`;
@@ -60,9 +60,9 @@ export default {
     releaseDateText() {
       if (this.releaseDate > 1) {
         return `Releases in ${this.releaseDate} days`;
-      } else if (this.releaseDate == 1) {
+      } else if (this.releaseDate === '1') {
         return 'Releases tomorrow';
-      } else if (this.releaseDate == 0) {
+      } else if (this.releaseDate === '0') {
         return 'Releases today';
       }
 

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -35,6 +35,23 @@ export default {
         && this.progresses[this.platform.code][this.game.id];
     },
 
+    releaseDate() {
+      const releaseDate = this.game
+        && this.game.release_dates
+        && this.game.release_dates.filter(({ platform }) => this.platform.id === platform)
+        && this.game.release_dates.filter(({ platform }) => this.platform.id === platform)[0].date;
+
+      const milisecUntil = releaseDate - Math.floor(Date.now() / 1000);
+
+      if (milisecUntil > 0) {
+        return Math.round(milisecUntil / (60 * 60 * 24));
+      } else if (milisecUntil < 0) {
+        return '';
+      }
+
+      return 'TBA';
+    },
+
     gameCardClass() {
       const badge = this.showGameInfoOnCover && this.gameProgress === '100'
         ? 'badge'

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -60,8 +60,10 @@ export default {
     releaseDateText() {
       if (this.releaseDate > 1) {
         return `Releases in ${this.releaseDate} days`;
-      } else if (this.releaseDate === 1) {
+      } else if (this.releaseDate == 1) {
         return 'Releases tomorrow';
+      } else if (this.releaseDate == 0) {
+        return 'Releases today';
       }
 
       return this.releaseDate;

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -60,7 +60,7 @@ export default {
       if (this.releaseDate > 1) {
         return `Releases in ${this.releaseDate} days`;
       } else if (this.releaseDate === 1) {
-        return "Releases tomorrow";
+        return 'Releases tomorrow';
       }
 
       return this.releaseDate;

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -56,6 +56,16 @@ export default {
       return 'TBA';
     },
 
+    releaseDateText() {
+      if (this.releaseDate > 1) {
+        return `Release in ${this.releaseDate} days`;
+      } else if (this.releaseDate === 1) {
+        return `Release in ${this.releaseDate} day`;
+      }
+      
+      return this.releaseDate;
+    },
+
     gameCardClass() {
       const badge = this.showGameInfoOnCover && this.gameProgress === '100'
         ? 'badge'

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -45,11 +45,12 @@ export default {
         && this.game.release_dates.filter(({ platform }) => this.platform.id === platform)
         && this.game.release_dates.filter(({ platform }) => this.platform.id === platform)[0].date;
 
-      const milisecUntil = releaseDate - Math.floor(Date.now() / 1000);
+      const daysUntilRelease = Math
+        .round((new Date(releaseDate * 1000) - new Date()) / (1000 * 60 * 60 * 24));
 
-      if (milisecUntil > 0) {
-        return Math.round(milisecUntil / (60 * 60 * 24));
-      } else if (milisecUntil < 0) {
+      if (daysUntilRelease > 0) {
+        return daysUntilRelease;
+      } else if (daysUntilRelease < 0) {
         return '';
       }
 

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { mapState, mapGetters } from 'vuex';
 
 export default {
@@ -42,21 +43,28 @@ export default {
     releaseDate() {
       const releaseDate = this.game
         && this.game.release_dates
-        && this.game.release_dates.filter(({ platform }) => this.platform.id === platform)
-        && this.game.release_dates.filter(({ platform }) => this.platform.id === platform)[0].date;
+        && this.game.release_dates.filter(
+          ({ platform }) => this.platform.id === platform,
+        )
+        && this.game.release_dates.filter(
+          ({ platform }) => this.platform.id === platform,
+        )[0].date
 
-      const daysUntilRelease = Math
-        .ceil((new Date(releaseDate * 1000) - new Date()) / (1000 * 60 * 60 * 24));
+      let daysUntilRelease = Math.ceil(moment.unix(releaseDate).diff(moment(), 'days', true));
 
-      if (daysUntilRelease >= 0) {
-        return daysUntilRelease === 0
-          ? 'Today'
-          : daysUntilRelease;
-      }
-
-      return daysUntilRelease < 0
-        ? ''
+      daysUntilRelease = daysUntilRelease
+        ? daysUntilRelease
         : 'TBA';
+
+      daysUntilRelease = daysUntilRelease < 0
+        ? ''
+        : daysUntilRelease;
+      
+      daysUntilRelease = daysUntilRelease >= 0 && daysUntilRelease === 0
+        ? 'Today'
+        : daysUntilRelease;
+
+      return daysUntilRelease;
     },
 
     releaseDateText() {

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -62,8 +62,10 @@ export default {
         return `Releases in ${this.releaseDate} days`;
       } else if (this.releaseDate === '1') {
         return 'Releases tomorrow';
-      } else if (this.releaseDate === '0') {
+      } else if (this.releaseDate === '0' && new Date().getHours() !== 12) {
         return 'Releases today';
+      } else if (this.releaseDate === '0' && new Date().getHours() === 15) {
+        return 'Released today';
       }
 
       return this.releaseDate;

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -62,9 +62,9 @@ export default {
         return `Releases in ${this.releaseDate} days`;
       } else if (this.releaseDate === '1') {
         return 'Releases tomorrow';
-      } else if (this.releaseDate === '0' && new Date().getHours() !== 12) {
+      } else if (this.releaseDate === '0' && new Date().getHours() < 15) {
         return 'Releases today';
-      } else if (this.releaseDate === '0' && new Date().getHours() === 15) {
+      } else if (this.releaseDate === '0') {
         return 'Released today';
       }
 

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -48,26 +48,26 @@ export default {
       const daysUntilRelease = Math
         .ceil((new Date(releaseDate * 1000) - new Date()) / (1000 * 60 * 60 * 24));
 
-      if (daysUntilRelease > 0) {
-        return daysUntilRelease;
-      } else if (daysUntilRelease === 0) {
-        return 'Today';
-      } else if (daysUntilRelease < 0) {
-        return '';
+      if (daysUntilRelease >= 0) {
+        return daysUntilRelease === 0
+          ? 'Today'
+          : daysUntilRelease;
       }
 
-      return 'TBA';
+      return daysUntilRelease < 0
+        ? ''
+        : 'TBA';
     },
 
     releaseDateText() {
-      if (this.releaseDate > 1) {
-        return `Releases in ${this.releaseDate} days`;
-      } else if (this.releaseDate === 1) {
-        return 'Releases tomorrow';
-      } else if (this.releaseDate === 'Today' && new Date().getHours() < 15) {
-        return 'Releases today';
+      if (this.releaseDate >= 1) {
+        return this.releaseDate === 1
+          ? 'Releases tomorrow'
+          : `Releases in ${this.releaseDate} days`;
       } else if (this.releaseDate === 'Today') {
-        return 'Released today';
+        return new Date().getHours() < 15
+          ? 'Releases today'
+          : 'Released today';
       }
 
       return this.releaseDate;

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -48,18 +48,18 @@ export default {
         )
         && this.game.release_dates.filter(
           ({ platform }) => this.platform.id === platform,
-        )[0].date
+        )[0].date;
 
       let daysUntilRelease = Math.ceil(moment.unix(releaseDate).diff(moment(), 'days', true));
 
-      daysUntilRelease = daysUntilRelease
-        ? daysUntilRelease
-        : 'TBA';
+      if (!daysUntilRelease) {
+        daysUntilRelease = 'TBA';
+      }
 
       daysUntilRelease = daysUntilRelease < 0
         ? ''
         : daysUntilRelease;
-      
+
       daysUntilRelease = daysUntilRelease >= 0 && daysUntilRelease === 0
         ? 'Today'
         : daysUntilRelease;

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -49,14 +49,14 @@ export default {
 
       let daysUntilRelease = releaseDate.date
         ? Math.ceil(moment.unix(releaseDate.date).diff(moment(), 'days', true))
-        : 'TBA';
+        : this.$t('releaseDates.ToBeAnnounced');
 
       daysUntilRelease = daysUntilRelease < 0
         ? ''
         : daysUntilRelease;
 
       daysUntilRelease = daysUntilRelease >= 0 && daysUntilRelease === 0
-        ? 'Today'
+        ? this.$t('releaseDates.Today')
         : daysUntilRelease;
 
       return daysUntilRelease;
@@ -65,12 +65,12 @@ export default {
     releaseDateText() {
       if (this.releaseDate >= 1) {
         return this.releaseDate === 1
-          ? 'Releases tomorrow'
-          : `Releases in ${this.releaseDate} days`;
-      } else if (this.releaseDate === 'Today') {
+          ? this.$t('releaseDates.ReleasesTomorrow')
+          : this.$t('releaseDates.ReleasesInXDays', { days: this.releaseDate });
+      } else if (this.releaseDate === this.$t('releaseDates.Today')) {
         return new Date().getHours() < 15
-          ? 'Releases today'
-          : 'Released today';
+          ? this.$t('releaseDates.ReleasesToday')
+          : this.$t('releaseDates.ReleasedToday');
       }
 
       return this.releaseDate;

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -20,6 +20,10 @@ export default {
       return this.game.rating && this.list && !this.list.hideGameRatings;
     },
 
+    showReleaseDates() {
+      return this.releaseDate && this.list && !this.list.hideReleaseDates;
+    },
+
     showGameInfo() {
       return this.list && !this.list.hideGameInfo;
     },

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -48,8 +48,10 @@ export default {
       const daysUntilRelease = Math
         .ceil((new Date(releaseDate * 1000) - new Date()) / (1000 * 60 * 60 * 24));
 
-      if (daysUntilRelease >= 0) {
-        return `${daysUntilRelease}`;
+      if (daysUntilRelease > 0) {
+        return daysUntilRelease;
+      } else if (daysUntilRelease === 0) {
+        return 'Today';
       } else if (daysUntilRelease < 0) {
         return '';
       }
@@ -60,11 +62,11 @@ export default {
     releaseDateText() {
       if (this.releaseDate > 1) {
         return `Releases in ${this.releaseDate} days`;
-      } else if (this.releaseDate === '1') {
+      } else if (this.releaseDate === 1) {
         return 'Releases tomorrow';
-      } else if (this.releaseDate === '0' && new Date().getHours() < 15) {
+      } else if (this.releaseDate === 'Today' && new Date().getHours() < 15) {
         return 'Releases today';
-      } else if (this.releaseDate === '0') {
+      } else if (this.releaseDate === 'Today') {
         return 'Released today';
       }
 

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -58,9 +58,9 @@ export default {
 
     releaseDateText() {
       if (this.releaseDate > 1) {
-        return `Release in ${this.releaseDate} days`;
+        return `Releases in ${this.releaseDate} days`;
       } else if (this.releaseDate === 1) {
-        return `Release in ${this.releaseDate} day`;
+        return `Releases tomorrow`;
       }
 
       return this.releaseDate;

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -48,13 +48,11 @@ export default {
         )
         && this.game.release_dates.filter(
           ({ platform }) => this.platform.id === platform,
-        )[0].date;
+        )[0];
 
-      let daysUntilRelease = Math.ceil(moment.unix(releaseDate).diff(moment(), 'days', true));
-
-      if (!daysUntilRelease) {
-        daysUntilRelease = 'TBA';
-      }
+      let daysUntilRelease = releaseDate.date
+        ? Math.ceil(moment.unix(releaseDate.date).diff(moment(), 'days', true))
+        : 'TBA';
 
       daysUntilRelease = daysUntilRelease < 0
         ? ''

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -48,8 +48,8 @@ export default {
       const daysUntilRelease = Math
         .round((new Date(releaseDate * 1000) - new Date()) / (1000 * 60 * 60 * 24));
 
-      if (daysUntilRelease > 0) {
-        return daysUntilRelease;
+      if (daysUntilRelease >= 0) {
+        return `${daysUntilRelease}`;
       } else if (daysUntilRelease < 0) {
         return '';
       }

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -43,12 +43,9 @@ export default {
     releaseDate() {
       const releaseDate = this.game
         && this.game.release_dates
-        && this.game.release_dates.filter(
+        && this.game.release_dates.find(
           ({ platform }) => this.platform.id === platform,
-        )
-        && this.game.release_dates.filter(
-          ({ platform }) => this.platform.id === platform,
-        )[0];
+        );
 
       let daysUntilRelease = releaseDate.date
         ? Math.ceil(moment.unix(releaseDate.date).diff(moment(), 'days', true))

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -60,7 +60,7 @@ export default {
       if (this.releaseDate > 1) {
         return `Releases in ${this.releaseDate} days`;
       } else if (this.releaseDate === 1) {
-        return `Releases tomorrow`;
+        return "Releases tomorrow";
       }
 
       return this.releaseDate;

--- a/src/components/GameCards/GameCard.js
+++ b/src/components/GameCards/GameCard.js
@@ -62,7 +62,7 @@ export default {
       } else if (this.releaseDate === 1) {
         return `Release in ${this.releaseDate} day`;
       }
-      
+
       return this.releaseDate;
     },
 

--- a/src/components/GameCards/GameCardCompact.vue
+++ b/src/components/GameCards/GameCardCompact.vue
@@ -26,6 +26,7 @@
         />
 
         <span
+          v-if="releaseDate"
           v-text="releaseDate"
           class="release-date drag-filter"
         >

--- a/src/components/GameCards/GameCardCompact.vue
+++ b/src/components/GameCards/GameCardCompact.vue
@@ -16,13 +16,21 @@
 
       <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
-      <game-rating
-        v-if="showGameRatings"
-        :rating="game.rating"
-        small
-        class="drag-filter"
-        @click.native="openDetails"
-      />
+      <div class="rating-release">
+        <game-rating
+          v-if="showGameRatings"
+          :rating="game.rating"
+          small
+          class="drag-filter"
+          @click.native="openDetails"
+        />
+
+        <span
+          v-text="releaseDate"
+          class="release-date drag-filter"
+        >
+        </span>
+      </div>
 
       <game-progress
         v-if="gameProgress"
@@ -134,9 +142,21 @@ export default {
         right: $gp / 4;
       }
 
+      .rating-release {
+        width: 100%;
+        display: grid;
+        grid-auto-flow: column;
+      }
+
       .game-rating, a {
         display: inline-flex;
         font-weight: bold;
+      }
+
+      .release-date {
+        color: var(--accent-color);
+        justify-self: end;
+        margin: $gp / 4 0;
       }
 
       &:hover {

--- a/src/components/GameCards/GameCardCompact.vue
+++ b/src/components/GameCards/GameCardCompact.vue
@@ -16,22 +16,20 @@
 
       <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
-      <div class="rating-release">
-        <game-rating
-          v-if="showGameRatings"
-          :rating="game.rating"
-          small
-          class="drag-filter"
-          @click.native="openDetails"
-        />
+      <span
+        v-if="showReleaseDates && releaseDate"
+        v-text="releaseDateText"
+        class="release-date drag-filter"
+      >
+      </span>
 
-        <span
-          v-if="showReleaseDates && releaseDate"
-          v-text="releaseDate"
-          class="release-date drag-filter"
-        >
-        </span>
-      </div>
+      <game-rating
+        v-if="showGameRatings"
+        :rating="game.rating"
+        small
+        class="drag-filter"
+        @click.native="openDetails"
+      />
 
       <game-progress
         v-if="gameProgress"
@@ -143,12 +141,6 @@ export default {
         right: $gp / 4;
       }
 
-      .rating-release {
-        width: 100%;
-        display: grid;
-        grid-auto-flow: column;
-      }
-
       .game-rating, a {
         display: inline-flex;
         font-weight: bold;
@@ -156,7 +148,6 @@ export default {
 
       .release-date {
         color: var(--accent-color);
-        justify-self: end;
         margin: $gp / 4 0;
       }
 

--- a/src/components/GameCards/GameCardCompact.vue
+++ b/src/components/GameCards/GameCardCompact.vue
@@ -26,7 +26,7 @@
         />
 
         <span
-          v-if="releaseDate"
+          v-if="showReleaseDates && releaseDate"
           v-text="releaseDate"
           class="release-date drag-filter"
         >

--- a/src/components/GameCards/GameCardDefault.vue
+++ b/src/components/GameCards/GameCardDefault.vue
@@ -25,13 +25,21 @@
         @click.native="openDetails"
       />
 
-      <game-rating
-        v-if="showGameRatings"
-        :rating="game.rating"
-        small
-        class="drag-filter"
-        @click.native="openDetails"
-      />
+      <div class="rating-release">
+        <game-rating
+          v-if="showGameRatings"
+          :rating="game.rating"
+          small
+          class="drag-filter"
+          @click.native="openDetails"
+        />
+
+        <span
+          v-text="releaseDate"
+          class="release-date drag-filter"
+        >
+        </span>
+      </div>
 
       <i
         v-if="note"
@@ -137,10 +145,22 @@ export default {
         right: $gp / 4;
       }
 
+      .rating-release {
+        width: 100%;
+        display: grid;
+        grid-auto-flow: column;
+      }
+
       .game-progress,
       .game-rating, a {
         display: inline-flex;
         font-weight: bold;
+      }
+
+      .release-date {
+        color: var(--accent-color);
+        justify-self: end;
+        margin: $gp / 4 0;
       }
 
       &:hover {

--- a/src/components/GameCards/GameCardDefault.vue
+++ b/src/components/GameCards/GameCardDefault.vue
@@ -17,6 +17,13 @@
 
       <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
+      <span
+        v-if="showReleaseDates && releaseDate"
+        v-text="releaseDateText"
+        class="release-date drag-filter"
+      >
+      </span>
+
       <game-progress
         v-if="gameProgress"
         small
@@ -25,22 +32,13 @@
         @click.native="openDetails"
       />
 
-      <div class="rating-release">
-        <game-rating
-          v-if="showGameRatings"
-          :rating="game.rating"
-          small
-          class="drag-filter"
-          @click.native="openDetails"
-        />
-
-        <span
-          v-if="showReleaseDates && releaseDate"
-          v-text="releaseDate"
-          class="release-date drag-filter"
-        >
-        </span>
-      </div>
+      <game-rating
+        v-if="showGameRatings"
+        :rating="game.rating"
+        small
+        class="drag-filter"
+        @click.native="openDetails"
+      />
 
       <i
         v-if="note"
@@ -146,12 +144,6 @@ export default {
         right: $gp / 4;
       }
 
-      .rating-release {
-        width: 100%;
-        display: grid;
-        grid-auto-flow: column;
-      }
-
       .game-progress,
       .game-rating, a {
         display: inline-flex;
@@ -160,7 +152,6 @@ export default {
 
       .release-date {
         color: var(--accent-color);
-        justify-self: end;
         margin: $gp / 4 0;
       }
 

--- a/src/components/GameCards/GameCardDefault.vue
+++ b/src/components/GameCards/GameCardDefault.vue
@@ -35,6 +35,7 @@
         />
 
         <span
+          v-if="releaseDate"
           v-text="releaseDate"
           class="release-date drag-filter"
         >

--- a/src/components/GameCards/GameCardDefault.vue
+++ b/src/components/GameCards/GameCardDefault.vue
@@ -35,7 +35,7 @@
         />
 
         <span
-          v-if="releaseDate"
+          v-if="showReleaseDates && releaseDate"
           v-text="releaseDate"
           class="release-date drag-filter"
         >

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -14,7 +14,7 @@
     />
 
     <span
-      v-if="!showGameInfo && showGameInfoOnCover && releaseDate"
+      v-if="!showGameInfo && showGameInfoOnCover && showReleaseDates && releaseDate"
       v-text="releaseDate"
       class="release-date drag-filter"
     >
@@ -42,6 +42,7 @@
           />
 
           <span
+            v-if="showReleaseDates && releaseDate"
             v-text="releaseDate"
             class="release-date drag-filter"
           >

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -25,13 +25,21 @@
           @click="openDetails"
         />
 
-        <game-rating
-          v-if="showGameRatings"
-          :rating="game.rating"
-          small
-          class="drag-filter"
-          @click.native="openDetails"
-        />
+        <div class="rating-release">
+          <game-rating
+            v-if="showGameRatings"
+            :rating="game.rating"
+            small
+            class="drag-filter"
+            @click.native="openDetails"
+          />
+
+          <span
+            v-text="releaseDate"
+            class="release-date drag-filter"
+          >
+          </span>
+        </div>
 
         <game-progress
           v-if="gameProgress"
@@ -155,9 +163,21 @@ export default {
       right: $gp / 4;
     }
 
+    .rating-release {
+      width: 100%;
+      display: grid;
+      grid-auto-flow: column;
+    }
+
     .game-rating, a {
       display: inline-flex;
       font-weight: bold;
+    }
+
+    .release-date {
+      color: var(--accent-color);
+      justify-self: end;
+      margin: $gp / 4 0;
     }
 
     &:hover {

--- a/src/components/GameCards/GameCardGrid.vue
+++ b/src/components/GameCards/GameCardGrid.vue
@@ -13,6 +13,13 @@
       @click.native="openDetails"
     />
 
+    <span
+      v-if="!showGameInfo && showGameInfoOnCover && releaseDate"
+      v-text="releaseDate"
+      class="release-date drag-filter"
+    >
+    </span>
+
     <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
     <div
@@ -129,11 +136,37 @@ export default {
       position: absolute;
       bottom: $gp / 6;
       left: $gp / 2;
+
+      + .release-date {
+        margin: 0;
+        position: absolute;
+        bottom: $gp * 1.5;
+        right: $gp / 2;
+        padding: $gp / 6 $gp / 4;
+        background: var(--list-background);
+      }
+    }
+
+    + .release-date {
+      margin: 0;
+      position: absolute;
+      bottom: $gp / 2;
+      right: $gp / 2;
+      padding: $gp / 6 $gp / 4;
+      background: var(--list-background);
     }
   }
 
   progress {
     max-width: 100%;
+  }
+
+  .release-date {
+    color: var(--accent-color);
+    font-weight: bold;
+    justify-self: end;
+    margin: $gp / 4 0;
+    border-radius: var(--border-radius);
   }
 
   .game-info {
@@ -172,12 +205,6 @@ export default {
     .game-rating, a {
       display: inline-flex;
       font-weight: bold;
-    }
-
-    .release-date {
-      color: var(--accent-color);
-      justify-self: end;
-      margin: $gp / 4 0;
     }
 
     &:hover {

--- a/src/components/GameCards/GameCardMasonry.vue
+++ b/src/components/GameCards/GameCardMasonry.vue
@@ -9,8 +9,6 @@
       @click="openDetails"
     >
 
-    <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
-
     <game-progress
       v-if="gameProgress"
       small
@@ -18,6 +16,15 @@
       :view="list.view"
       @click.native="openDetails"
     />
+
+    <span
+      v-if="releaseDate"
+      v-text="releaseDate"
+      class="release-date drag-filter"
+    >
+    </span>
+
+    <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
   </div>
 </template>
 
@@ -50,6 +57,15 @@ export default {
   img {
     width: 100%;
     height: auto;
+
+    + .release-date {
+      margin: 0;
+      position: absolute;
+      bottom: $gp / 4;
+      right: $gp / 4;
+      padding: $gp / 8 $gp / 6;
+      background: var(--list-background);
+    }
   }
 
   .game-progress {
@@ -57,6 +73,24 @@ export default {
     position: absolute;
     bottom: $gp / 6;
     left: $gp / 2;
+
+    + .release-date {
+      margin: 0;
+      position: absolute;
+      bottom: $gp * 1.5;
+      right: $gp / 2;
+      padding: $gp / 8 $gp / 6;
+      background: var(--list-background);
+    }
+  }
+
+  .release-date {
+    color: var(--accent-color);
+    font-size: $font-size-xsmall;
+    font-weight: bold;
+    justify-self: end;
+    margin: $gp / 4 0;
+    border-radius: calc(var(--border-radius) / 2);
   }
 
   .draggable-icon {

--- a/src/components/GameCards/GameCardMasonry.vue
+++ b/src/components/GameCards/GameCardMasonry.vue
@@ -18,7 +18,7 @@
     />
 
     <span
-      v-if="showGameInfoOnCover && releaseDate"
+      v-if="showReleaseDates && showGameInfoOnCover && releaseDate"
       v-text="releaseDate"
       class="release-date drag-filter"
     >

--- a/src/components/GameCards/GameCardMasonry.vue
+++ b/src/components/GameCards/GameCardMasonry.vue
@@ -10,7 +10,7 @@
     >
 
     <game-progress
-      v-if="gameProgress"
+      v-if="showGameInfoOnCover && gameProgress"
       small
       :progress="gameProgress"
       :view="list.view"
@@ -18,7 +18,7 @@
     />
 
     <span
-      v-if="releaseDate"
+      v-if="showGameInfoOnCover && releaseDate"
       v-text="releaseDate"
       class="release-date drag-filter"
     >

--- a/src/components/GameCards/GameCardText.vue
+++ b/src/components/GameCards/GameCardText.vue
@@ -4,6 +4,13 @@
       <a v-text="game.name" class="drag-filter" @click="openDetails"/>
       <i class="fas fa-grip-vertical draggable-icon game-drag-handle" />
 
+      <span
+        v-if="showReleaseDates && releaseDate"
+        v-text="releaseDateText"
+        class="release-date drag-filter"
+      >
+      </span>
+
       <game-rating
         v-if="showGameRatings && list.view !== 'covers'"
         :rating="game.rating"
@@ -12,22 +19,13 @@
         @click.native="openDetails"
       />
 
-      <div class="rating-release">
-        <game-progress
-          v-if="gameProgress"
-          small
-          :progress="gameProgress"
-          class="drag-filter"
-          @click.native="openDetails"
-        />
-
-        <span
-          v-if="showReleaseDates && releaseDate"
-          v-text="releaseDate"
-          class="release-date drag-filter"
-        >
-        </span>
-      </div>
+      <game-progress
+        v-if="gameProgress"
+        small
+        :progress="gameProgress"
+        class="drag-filter"
+        @click.native="openDetails"
+      />
 
       <i
         v-if="note"
@@ -123,12 +121,6 @@ export default {
         right: $gp / 4;
       }
 
-      .rating-release {
-        width: 100%;
-        display: grid;
-        grid-auto-flow: column;
-      }
-
       .game-rating, a {
         display: inline-flex;
         font-weight: bold;
@@ -136,7 +128,6 @@ export default {
 
       .release-date {
         color: var(--accent-color);
-        justify-self: end;
         margin: $gp / 4 0;
       }
 

--- a/src/components/GameCards/GameCardText.vue
+++ b/src/components/GameCards/GameCardText.vue
@@ -22,7 +22,7 @@
         />
 
         <span
-          v-if="releaseDate"
+          v-if="showReleaseDates && releaseDate"
           v-text="releaseDate"
           class="release-date drag-filter"
         >

--- a/src/components/GameCards/GameCardText.vue
+++ b/src/components/GameCards/GameCardText.vue
@@ -12,13 +12,21 @@
         @click.native="openDetails"
       />
 
-      <game-progress
-        v-if="gameProgress"
-        small
-        :progress="gameProgress"
-        class="drag-filter"
-        @click.native="openDetails"
-      />
+      <div class="rating-release">
+        <game-progress
+          v-if="gameProgress"
+          small
+          :progress="gameProgress"
+          class="drag-filter"
+          @click.native="openDetails"
+        />
+
+        <span
+          v-text="releaseDate"
+          class="release-date drag-filter"
+        >
+        </span>
+      </div>
 
       <i
         v-if="note"
@@ -114,9 +122,21 @@ export default {
         right: $gp / 4;
       }
 
+      .rating-release {
+        width: 100%;
+        display: grid;
+        grid-auto-flow: column;
+      }
+
       .game-rating, a {
         display: inline-flex;
         font-weight: bold;
+      }
+
+      .release-date {
+        color: var(--accent-color);
+        justify-self: end;
+        margin: $gp / 4 0;
       }
 
       &:hover {

--- a/src/components/GameCards/GameCardText.vue
+++ b/src/components/GameCards/GameCardText.vue
@@ -22,6 +22,7 @@
         />
 
         <span
+          v-if="releaseDate"
           v-text="releaseDate"
           class="release-date drag-filter"
         >

--- a/src/components/GameDetail/GameProgress.vue
+++ b/src/components/GameDetail/GameProgress.vue
@@ -85,7 +85,7 @@ export default {
       width: 100%;
       margin: $gp / 4 0;
       overflow: hidden;
-      border-radius: var(--border-radius);
+      border-radius: calc(var(--border-radius) / 2);
     }
 
     .progress-bar-label {

--- a/src/components/GameDetail/GameProgress.vue
+++ b/src/components/GameDetail/GameProgress.vue
@@ -85,7 +85,7 @@ export default {
       width: 100%;
       margin: $gp / 4 0;
       overflow: hidden;
-      border-radius: var(--border-radius) / 2;
+      border-radius: var(--border-radius);
     }
 
     .progress-bar-label {

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -20,28 +20,7 @@
     </header>
 
     <draggable
-      v-if="view === 'masonry'"
-      :class="`game-masonry game-masonry-${listIndex}`"
-      :list="gameList"
-      :id="listIndex"
-      :move="validateMove"
-      v-bind="gameDraggableOptions"
-      @end="dragEnd"
-      @start="dragStart"
-    >
-      <component
-        v-for="game in sortedGames"
-        :is="gameCardComponent"
-        :key="`masonry-${game}`"
-        :id="game"
-        :game-id="game"
-        :list-id="listIndex"
-      />
-    </draggable>
-
-    <draggable
-      v-else
-      class="games"
+      :class="gamesClass"
       :list="gameList"
       :id="listIndex"
       :move="validateMove"
@@ -219,6 +198,12 @@ export default {
 
     viewClass() {
       return this.list[this.listIndex].view || 'single';
+    },
+
+    gamesClass() {
+      return this.list[this.listIndex].view === 'masonry'
+        ? `game-masonry game-masonry-${this.listIndex}`
+        : 'games';
     },
 
     hideGameRatings() {

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -225,6 +225,10 @@ export default {
       return this.list[this.listIndex].hideGameRatings || false;
     },
 
+    hideReleaseDates() {
+      return this.list[this.listIndex].hideReleaseDates || false;
+    },
+
     hideGameInfo() {
       return this.list[this.listIndex].hideGameInfo || false;
     },

--- a/src/components/Lists/List.vue
+++ b/src/components/Lists/List.vue
@@ -30,7 +30,7 @@
       @start="dragStart"
     >
       <component
-        v-for="game in gameList"
+        v-for="game in sortedGames"
         :is="gameCardComponent"
         :key="`masonry-${game}`"
         :id="game"

--- a/src/components/Lists/ListSettingsModal.vue
+++ b/src/components/Lists/ListSettingsModal.vue
@@ -88,7 +88,7 @@
         />
       </section>
 
-      <section :class="{ disabled: !localList.hideGameInfo }" v-if="localList.view === 'grid'">
+      <section :class="{ disabled: !localList.hideGameInfo }" v-if="localList.view === 'grid' || localList.view === 'masonry'">
         <h4>Hide game info on top of game covers</h4>
 
         <toggle-switch

--- a/src/components/Lists/ListSettingsModal.vue
+++ b/src/components/Lists/ListSettingsModal.vue
@@ -88,7 +88,10 @@
         />
       </section>
 
-      <section :class="{ disabled: !localList.hideGameInfo }" v-if="localList.view === 'grid' || localList.view === 'masonry'">
+      <section
+        :class="{disabled: !localList.hideGameInfo }"
+        v-if="localList.view === 'grid' || localList.view === 'masonry'"
+      >
         <h4>Hide game info on top of game covers</h4>
 
         <toggle-switch

--- a/src/components/Lists/ListSettingsModal.vue
+++ b/src/components/Lists/ListSettingsModal.vue
@@ -133,6 +133,16 @@
         />
       </section>
 
+      <section>
+        <h4>Hide days until release</h4>
+
+        <toggle-switch
+          id="releaseDates"
+          @change="save"
+          v-model="localList.hideReleaseDates"
+        />
+      </section>
+
       <footer>
         <modal
           v-if="localList && localList.games && localList.games.length"

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -1,13 +1,13 @@
 {
     "global": {
-        "back": "الى الخلف",
+        "back": "عودة",
         "save": "حفظ",
         "cancel": "إلغاء",
         "create": "خلق",
         "filter": "منقي",
         "by": "بواسطة",
         "no": "لا",
-        "yes": "نعم فعلا",
+        "yes": "نعم",
         "or": "أو",
         "returnHome": "العودة إلى المنزل",
         "pageNotFound": "الصفحة غير موجودة"
@@ -28,7 +28,7 @@
         "computer": "الكمبيوتر المنزلي",
         "releaseYear": "صدر العام",
         "name": "أبجديا",
-        "type": "نوع"
+        "type": "اكتب"
     },
     "igdbCredit": {
         "poweredByIgdb": "مدعوم من IGDB"
@@ -43,7 +43,7 @@
     "sessionExpired": {
         "title": "انتهت الجلسة",
         "login": "تسجيل الدخول",
-        "exit": "ىخرج"
+        "exit": "خروج"
     },
     "gameDetail": {
         "videos": "أشرطة فيديو",
@@ -51,7 +51,7 @@
         "perspective": "إنطباع",
         "releaseDate": "يوم الاصدار",
         "timeToBeat": "الوقت يداهمك",
-        "gameModes": "وضع اللعب",
+        "gameModes": "نوع اللعبة",
         "genres": "نوع أدبي",
         "gamePlatforms": "متاح أيضًا لـ:",
         "developers": "مطور",
@@ -61,9 +61,9 @@
             "official": "موقع رسمي",
             "wikia": "فندوم",
             "wikipedia": "ويكيبيديا",
-            "facebook": "فيس بوك",
-            "twitter": "تغريد",
-            "twitch": "نشل",
+            "facebook": "موقع التواصل الاجتماعي الفيسبوك",
+            "twitter": "تويتر",
+            "twitch": "تويتش",
             "instagram": "إينستاجرام",
             "youtube": "موقع يوتيوب",
             "iphone": "دائرة الرقابة الداخلية",
@@ -84,7 +84,7 @@
         "type": "نوع القائمة",
         "settings": "قائمة الإعدادات",
         "placeholder": "اكتب اسم قائمتك هنا",
-        "wishlist": "الأماني",
+        "wishlist": "قائمة الرغبات",
         "input": "أدخل بنفسك",
         "add": "اضف قائمة",
         "duplicateWarning": "لديك بالفعل قائمة بهذا الاسم",
@@ -94,22 +94,23 @@
         "sortByProgress": "تقدم",
         "sortByRating": "أحرز هدفا",
         "sortByReleaseDate": "تاريخ",
-        "sortByCustom": "العادة",
+        "sortByCustom": "مخصص",
         "delete": "حذف القائمة",
         "moveLeft": "تحرك يسارا",
         "moveRight": "تحرك يمينا",
         "emptyList": "هذه القائمة فارغة",
         "addGame": "إضافة اللعبة",
+        "addGames": "إضافة ألعاب إلى {listName}",
         "view": "عرض القائمة",
         "moveList": "نقل القائمة",
         "sortList": "قائمة الفرز التلقائي",
         "coversSizeTitle": "يغطي عبر",
         "views": {
-            "single": "افتراضي",
-            "wide": "المدمج",
+            "single": "إفتراضي",
+            "compact": "المدمج",
             "text": "نص فقط",
             "masonry": "ماسونية",
-            "grid": "شبكة"
+            "grid": "جريد"
         }
     },
     "settings": {
@@ -128,10 +129,10 @@
         "languages": {
             "en": "الإنجليزية",
             "es": "الأسبانية",
-            "pl": "البولندي",
+            "pl": "تلميع",
             "de": "ألمانية",
             "ar": "عربى",
-            "fr": "الفرنسية",
+            "fr": "فرنسي",
             "it": "الإيطالي",
             "eu": "الباسكي",
             "cs": "تشيكي",
@@ -143,7 +144,7 @@
         "signOut": "خروج",
         "wallpaper": {
             "title": "تحميل خلفية",
-            "transparency": "اسمح بالشفافية",
+            "transparency": "السماح بالشفافية",
             "currentWallpaper": "خلفية الحالية",
             "wallpaper": "ورق الجدران",
             "removeWallpaper": "إزالة خلفية"
@@ -176,7 +177,18 @@
         "notes": "ملاحظات"
     },
     "progresses": {
+        "modalTitle": "ضبط تقدم اللعبة",
         "addProgress": "إضافة التقدم",
+        "updateProgress": "كم لم ترسلها",
+        "deleteProgress": "حذف التقدم",
         "progresses": "تقدم"
+    },
+    "releaseDates": {
+        "Today": "اليوم",
+        "ReleasesToday": "النشرات اليوم",
+        "ReleasedToday": "صدر اليوم",
+        "ReleasesTomorrow": "إصدارات غدا",
+        "ReleasesInXDays": "الإصدارات في {أيام}",
+        "ToBeAnnounced": "TBA"
     }
 }

--- a/src/i18n/cs.json
+++ b/src/i18n/cs.json
@@ -100,13 +100,14 @@
         "moveRight": "Pohyb vpravo",
         "emptyList": "Tento seznam je prázdný",
         "addGame": "Přidat hru",
+        "addGames": "Přidat hry do {listName}",
         "view": "Zobrazení seznamu",
         "moveList": "Přesunout seznam",
         "sortList": "Seznam automatického třídění",
         "coversSizeTitle": "Přikrývá se",
         "views": {
             "single": "Výchozí",
-            "wide": "Kompaktní",
+            "compact": "Kompaktní",
             "text": "Pouze text",
             "masonry": "Zdivo",
             "grid": "Mřížka"
@@ -158,14 +159,14 @@
         "title": "Herní štítky",
         "addTag": "Přidat značku",
         "createTag": "Vytvořit značku",
-        "inputPlaceholder": "Název značky",
+        "inputPlaceholder": "Název štítku",
         "editTags": "Úpravy herních značek",
         "message": "Kliknutím na značku ji přidáte do <a>{gameName}</a> . Klikněte na <i class=\"fas fa-times close\"></i> odebrat značku.",
         "settingsMessage": "Existující značky můžete přidat nebo upravit v nastavení."
     },
     "gameSearch": {
         "title": "Přidejte hry do",
-        "inputPlaceholder": "Hledej zde",
+        "inputPlaceholder": "Hledej tady",
         "alreadyInList": "z výsledků vyhledávání již ve vašem seznamu",
         "noResultsFound": "Žádné výsledky",
         "missingGame": "Chybí vám hra? Pomozte komunitě a",
@@ -176,7 +177,18 @@
         "notes": "Poznámky"
     },
     "progresses": {
+        "modalTitle": "Nastavit postup hry",
         "addProgress": "Přidejte pokrok",
+        "updateProgress": "Aktualizace průběhu",
+        "deleteProgress": "Smazat pokrok",
         "progresses": "Pokrok"
+    },
+    "releaseDates": {
+        "Today": "Dnes",
+        "ReleasesToday": "Vydání dnes",
+        "ReleasedToday": "Vydáno dnes",
+        "ReleasesTomorrow": "Vydání zítra",
+        "ReleasesInXDays": "Vydání za {dny} dní",
+        "ToBeAnnounced": "TBA"
     }
 }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -23,7 +23,7 @@
         "donating": "spenden",
         "reportBugs": "Fehler melden",
         "submitFeedback": "Feedback senden",
-        "home": "Hauptkonsolen",
+        "home": "Heimkonsolen",
         "handheld": "Handhelds",
         "computer": "Heimcomputer",
         "releaseYear": "Jahr veröffentlicht",
@@ -31,11 +31,11 @@
         "type": "Art"
     },
     "igdbCredit": {
-        "poweredByIgdb": "Bereitgestellt von IGDB"
+        "poweredByIgdb": "Powered by IGDB"
     },
     "gameBoard": {
         "settings": {
-            "wallpaper": "Benutzerdefinierte Wallpaper",
+            "wallpaper": "Benutzerdefiniertes Hintergrundbild",
             "shareLink": "Gemeinsam nutzbare Links (experimentell)",
             "dangerZone": "Gefahrenzone"
         }
@@ -56,7 +56,7 @@
         "gamePlatforms": "Auch erhältlich für:",
         "developers": "Entwickler",
         "publishers": "Verlag",
-        "removeFromList": "Löschen",
+        "removeFromList": "Entfernen",
         "links": {
             "official": "Offizielle Seite",
             "wikia": "Fangemeinde",
@@ -80,7 +80,7 @@
         }
     },
     "list": {
-        "edit": "Listenname bearbeiten",
+        "edit": "Listennamen bearbeiten",
         "type": "Listentyp",
         "settings": "Listeneinstellungen",
         "placeholder": "Geben Sie hier Ihren Listennamen ein",
@@ -89,24 +89,25 @@
         "add": "Liste hinzufügen",
         "duplicateWarning": "Sie haben bereits eine Liste mit diesem Namen",
         "getStarted": "Loslegen!",
-        "addFirstTime": "Willkommen, füge deine erste Liste hinzu!",
+        "addFirstTime": "Willkommen, fügen Sie Ihre erste Liste hinzu!",
         "sortByName": "DAS",
         "sortByProgress": "Fortschritt",
         "sortByRating": "Ergebnis",
         "sortByReleaseDate": "Datum",
-        "sortByCustom": "Brauch",
+        "sortByCustom": "Benutzerdefiniert",
         "delete": "Liste löschen",
         "moveLeft": "Geh nach links",
         "moveRight": "Nach rechts bewegen",
         "emptyList": "Diese Liste ist leer",
         "addGame": "Spiel hinzufügen",
+        "addGames": "Spiele zu {listName} hinzufügen",
         "view": "Listenansicht",
         "moveList": "Liste verschieben",
-        "sortList": "Automatische Sortierliste",
-        "coversSizeTitle": "Abdeckungen herüber",
+        "sortList": "Liste der automatischen Sortierung",
+        "coversSizeTitle": "Deckt über",
         "views": {
             "single": "Standard",
-            "wide": "Kompakt",
+            "compact": "Kompakt",
             "text": "Nur Text",
             "masonry": "Mauerwerk",
             "grid": "Gitter"
@@ -121,8 +122,8 @@
         "account": "Konto",
         "global": "Global",
         "reloading": "Neuladen...",
-        "releases": "Releases",
-        "newsletter": "Erhalte Update-E-Mails (in Kürze)",
+        "releases": "Veröffentlichungen",
+        "newsletter": "Erhalten Sie Update-E-Mails (in Kürze)",
         "branding": "Plattform-Branding (Farben, Logo usw.)",
         "language": "Sprache",
         "languages": {
@@ -145,7 +146,7 @@
             "title": "Hintergrundbild hochladen",
             "transparency": "Transparenz zulassen",
             "currentWallpaper": "Aktuelles Hintergrundbild",
-            "wallpaper": "Tapete",
+            "wallpaper": "Hintergrund",
             "removeWallpaper": "Tapete entfernen"
         },
         "deleteAccount": {
@@ -155,12 +156,12 @@
         }
     },
     "tags": {
-        "title": "Spieletags",
+        "title": "Spiel-Tags",
         "addTag": "Tag hinzufügen",
         "createTag": "Tag erstellen",
-        "inputPlaceholder": "Tag name",
+        "inputPlaceholder": "Verlinke den Namen",
         "editTags": "Spiel-Tags bearbeiten",
-        "message": "Klicken Sie auf das Tag, um es zu <a>{gameName} hinzuzufügen</a> . Klicke auf <i class=\"fas fa-times close\"></i> tag entfernen.",
+        "message": "Klicken Sie auf das Tag, um es zu <a>{gameName} hinzuzufügen</a> . Klicke auf <i class=\"fas fa-times close\"></i> Tag entfernen.",
         "settingsMessage": "Sie können vorhandene Tags in den Einstellungen hinzufügen oder bearbeiten."
     },
     "gameSearch": {
@@ -169,14 +170,25 @@
         "alreadyInList": "aus Suchergebnissen, die bereits in Ihrer Liste enthalten sind",
         "noResultsFound": "Keine Ergebnisse",
         "missingGame": "Vermissen Sie ein Spiel? Helfen Sie der Community und",
-        "addToIGDB": "Fügen Sie es zu IGDB hinzu"
+        "addToIGDB": "Fügen Sie es der IGDB hinzu"
     },
     "notes": {
         "addNote": "Notiz hinzufügen",
         "notes": "Anmerkungen"
     },
     "progresses": {
+        "modalTitle": "Spielfortschritt einstellen",
         "addProgress": "Fortschritt hinzufügen",
+        "updateProgress": "Aktualisierungsfortschritt",
+        "deleteProgress": "Fortschritt löschen",
         "progresses": "Fortschritt"
+    },
+    "releaseDates": {
+        "Today": "Heute",
+        "ReleasesToday": "Veröffentlicht heute",
+        "ReleasedToday": "Heute veröffentlicht",
+        "ReleasesTomorrow": "Veröffentlicht morgen",
+        "ReleasesInXDays": "Veröffentlichungen in {Tagen} Tagen",
+        "ToBeAnnounced": "TBA"
     }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -182,5 +182,13 @@
     "updateProgress": "Update progress",
     "deleteProgress": "Delete progress",
     "progresses": "Progress"
+  },
+  "releaseDates": {
+    "Today": "Today",
+    "ReleasesToday": "Releases today",
+    "ReleasedToday": "Released today",
+    "ReleasesTomorrow": "Releases tomorrow",
+    "ReleasesInXDays": "Releases in {days} days",
+    "ToBeAnnounced": "TBA"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -6,8 +6,8 @@
         "create": "Crear",
         "filter": "Filtrar",
         "by": "por",
-        "no": "no",
-        "yes": "sí",
+        "no": "No",
+        "yes": "si",
         "or": "o",
         "returnHome": "Volver a casa",
         "pageNotFound": "Página no encontrada"
@@ -25,7 +25,7 @@
         "submitFeedback": "enviando comentarios",
         "home": "Consolas para el hogar",
         "handheld": "Dispositivos de mano",
-        "computer": "Computador del hogar",
+        "computer": "Computadora de casa",
         "releaseYear": "Año de lanzamiento",
         "name": "Alfabéticamente",
         "type": "Tipo"
@@ -56,7 +56,7 @@
         "gamePlatforms": "También disponible para:",
         "developers": "Desarrollador",
         "publishers": "Editores",
-        "removeFromList": "retirar",
+        "removeFromList": "Eliminar",
         "links": {
             "official": "Sitio oficial",
             "wikia": "Fandom",
@@ -97,16 +97,17 @@
         "sortByCustom": "Personalizado",
         "delete": "Eliminar lista",
         "moveLeft": "Mover hacia la izquierda",
-        "moveRight": "Moverse a la derecha",
+        "moveRight": "Mover a la derecha",
         "emptyList": "Esta lista esta vacia",
         "addGame": "Agregar juego",
+        "addGames": "Agregar juegos a {listName}",
         "view": "Vista de la lista",
         "moveList": "Mover lista",
         "sortList": "Lista de ordenación automática",
         "coversSizeTitle": "Cubre a través de",
         "views": {
             "single": "Defecto",
-            "wide": "Compacto",
+            "compact": "Compacto",
             "text": "Solo texto",
             "masonry": "Albañilería",
             "grid": "Cuadrícula"
@@ -145,7 +146,7 @@
             "title": "Subir fondo de pantalla",
             "transparency": "Permitir transparencia",
             "currentWallpaper": "Fondo de pantalla actual",
-            "wallpaper": "Papel pintado",
+            "wallpaper": "Fondo de pantalla",
             "removeWallpaper": "Eliminar fondo de pantalla"
         },
         "deleteAccount": {
@@ -160,7 +161,7 @@
         "createTag": "Crear etiqueta",
         "inputPlaceholder": "Nombre de etiqueta",
         "editTags": "Editar etiquetas de juego",
-        "message": "Haga clic en la etiqueta para agregarla a <a>{gameName}</a> . Haga clic en <i class=\"fas fa-times close\"></i> para eliminar la etiqueta",
+        "message": "Haz clic en la etiqueta para agregarla a <a>{gameName}</a> . Haga clic en <i class=\"fas fa-times close\"></i> para eliminar la etiqueta",
         "settingsMessage": "Puede agregar o editar etiquetas existentes en la configuración."
     },
     "gameSearch": {
@@ -176,7 +177,18 @@
         "notes": "Notas"
     },
     "progresses": {
+        "modalTitle": "Establecer progreso del juego",
         "addProgress": "Agregar progreso",
+        "updateProgress": "Progreso de actualización",
+        "deleteProgress": "Eliminar progreso",
         "progresses": "Progreso"
+    },
+    "releaseDates": {
+        "Today": "Hoy",
+        "ReleasesToday": "Lanzamientos hoy",
+        "ReleasedToday": "Lanzado hoy",
+        "ReleasesTomorrow": "Estrenos mañana",
+        "ReleasesInXDays": "Lanzamientos en {días} días",
+        "ToBeAnnounced": "TBA"
     }
 }

--- a/src/i18n/eu.json
+++ b/src/i18n/eu.json
@@ -87,7 +87,7 @@
         "wishlist": "Gustuko",
         "input": "Sartu zurea",
         "add": "Gehitu zerrenda",
-        "duplicateWarning": "Izen horrekin zerrenda bat duzu jada",
+        "duplicateWarning": "Dagoeneko izen hori duen zerrenda duzu",
         "getStarted": "Hasi!",
         "addFirstTime": "Ongi etorri, gehitu zure lehen zerrenda!",
         "sortByName": "THE",
@@ -100,13 +100,14 @@
         "moveRight": "Mugitu eskuinera",
         "emptyList": "Zerrenda hau hutsik dago",
         "addGame": "Gehitu jokoa",
+        "addGames": "Gehitu jokoak {listName} (e) ra jokoak",
         "view": "Zerrenda ikuspegia",
         "moveList": "Mugitu zerrenda",
-        "sortList": "Auto ordenazioen zerrenda",
+        "sortList": "Ordenaketa automatikoen zerrenda",
         "coversSizeTitle": "Estaldurak zehar",
         "views": {
             "single": "Default",
-            "wide": "Compact",
+            "compact": "Compact",
             "text": "Testua soilik",
             "masonry": "Masoneria",
             "grid": "Grid"
@@ -176,7 +177,18 @@
         "notes": "Oharrak"
     },
     "progresses": {
-        "addProgress": "Gehitu aurrerapenak",
+        "modalTitle": "Ezarri jokoaren aurrerapena",
+        "addProgress": "Aurrerapenak gehitu",
+        "updateProgress": "Eguneratu aurrerapen",
+        "deleteProgress": "Ezabatu aurrerapenak",
         "progresses": "Eraikitzen"
+    },
+    "releaseDates": {
+        "Today": "gaur",
+        "ReleasesToday": "Kaleratzeak gaur",
+        "ReleasedToday": "Gaur kaleratua",
+        "ReleasesTomorrow": "Kaleak bihar",
+        "ReleasesInXDays": "Oharrak {egun} egunetan",
+        "ToBeAnnounced": "zehazteke"
     }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,7 +1,7 @@
 {
     "global": {
         "back": "Retour",
-        "save": "sauver",
+        "save": "sauvegarder",
         "cancel": "Annuler",
         "create": "Créer",
         "filter": "Filtre",
@@ -62,7 +62,7 @@
             "wikia": "Fandom",
             "wikipedia": "Wikipédia",
             "facebook": "Facebook",
-            "twitter": "Gazouillement",
+            "twitter": "Twitter",
             "twitch": "Tic",
             "instagram": "Instagram",
             "youtube": "Youtube",
@@ -93,20 +93,21 @@
         "sortByName": "LA",
         "sortByProgress": "Le progrès",
         "sortByRating": "But",
-        "sortByReleaseDate": "Rendez-vous amoureux",
+        "sortByReleaseDate": "Date",
         "sortByCustom": "Douane",
         "delete": "Supprimer la liste",
         "moveLeft": "Se déplacer à gauche",
         "moveRight": "Déplacer vers la droite",
         "emptyList": "Cette liste est vide",
         "addGame": "Ajouter un jeu",
-        "view": "Affichage liste",
+        "addGames": "Ajouter des jeux à {listName}",
+        "view": "Vue liste",
         "moveList": "Déplacer la liste",
         "sortList": "Liste de tri automatique",
         "coversSizeTitle": "Couvre à travers",
         "views": {
             "single": "Défaut",
-            "wide": "Compact",
+            "compact": "Compact",
             "text": "Texte seulement",
             "masonry": "Maçonnerie",
             "grid": "la grille"
@@ -123,11 +124,11 @@
         "reloading": "Rechargement ...",
         "releases": "Communiqués",
         "newsletter": "Recevez des e-mails de mise à jour (à venir bientôt)",
-        "branding": "Marque de la plateforme (couleurs, logo, etc ...)",
-        "language": "La langue",
+        "branding": "Marquage de la plateforme (couleurs, logo, etc ...)",
+        "language": "Langue",
         "languages": {
             "en": "Anglais",
-            "es": "Espanol",
+            "es": "Espagnol",
             "pl": "polonais",
             "de": "allemand",
             "ar": "arabe",
@@ -176,7 +177,18 @@
         "notes": "Remarques"
     },
     "progresses": {
+        "modalTitle": "Définir la progression du jeu",
         "addProgress": "Ajouter des progrès",
+        "updateProgress": "Progression de la mise à jour",
+        "deleteProgress": "Supprimer la progression",
         "progresses": "Le progrès"
+    },
+    "releaseDates": {
+        "Today": "Aujourd'hui",
+        "ReleasesToday": "Sorties aujourd'hui",
+        "ReleasedToday": "Sorti aujourd'hui",
+        "ReleasesTomorrow": "Sort demain",
+        "ReleasesInXDays": "Sorties dans {jours} jours",
+        "ToBeAnnounced": "TBA"
     }
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1,7 +1,7 @@
 {
     "global": {
         "back": "Indietro",
-        "save": "Salvare",
+        "save": "Salva",
         "cancel": "Annulla",
         "create": "Creare",
         "filter": "Filtro",
@@ -100,13 +100,14 @@
         "moveRight": "Vai a destra",
         "emptyList": "Questo elenco è vuoto",
         "addGame": "Aggiungi gioco",
+        "addGames": "Aggiungi giochi a {listName}",
         "view": "Visualizzazione elenco",
         "moveList": "Sposta elenco",
         "sortList": "Elenco di ordinamento automatico",
         "coversSizeTitle": "Copre attraverso",
         "views": {
             "single": "Predefinito",
-            "wide": "Compatto",
+            "compact": "Compatto",
             "text": "Solo testo",
             "masonry": "Opere murarie",
             "grid": "Griglia"
@@ -122,7 +123,7 @@
         "global": "Globale",
         "reloading": "Ricaricamento ...",
         "releases": "Uscite",
-        "newsletter": "Ricevi email di aggiornamento (in arrivo)",
+        "newsletter": "Ricevi email di aggiornamento (presto in arrivo)",
         "branding": "Marchio della piattaforma (colori, logo, ecc ...)",
         "language": "linguaggio",
         "languages": {
@@ -173,10 +174,21 @@
     },
     "notes": {
         "addNote": "Aggiungi nota",
-        "notes": "Gli appunti"
+        "notes": "Appunti"
     },
     "progresses": {
+        "modalTitle": "Imposta i progressi del gioco",
         "addProgress": "Aggiungi progressi",
+        "updateProgress": "Avanzamento dell'aggiornamento",
+        "deleteProgress": "Elimina progressi",
         "progresses": "Progresso"
+    },
+    "releaseDates": {
+        "Today": "Oggi",
+        "ReleasesToday": "Rilasci oggi",
+        "ReleasedToday": "Rilasciato oggi",
+        "ReleasesTomorrow": "Rilascia domani",
+        "ReleasesInXDays": "Rilasci tra {giorni} giorni",
+        "ToBeAnnounced": "TBA"
     }
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -5,8 +5,8 @@
         "cancel": "キャンセル",
         "create": "作成する",
         "filter": "フィルタ",
-        "by": "によって",
-        "no": "いや",
+        "by": "沿って",
+        "no": "番号",
         "yes": "はい",
         "or": "または",
         "returnHome": "帰宅",
@@ -19,7 +19,7 @@
         "published": "{date}を公開しました"
     },
     "platforms": {
-        "donateMessage": "Gamebraryは無料でオープンソースです。その開発を支援することを検討してください",
+        "donateMessage": "Gamebraryは無料でオープンソースです。",
         "donating": "寄付",
         "reportBugs": "バグを報告する",
         "submitFeedback": "フィードバックを送信する",
@@ -42,7 +42,7 @@
     },
     "sessionExpired": {
         "title": "セッションの有効期限が切れ",
-        "login": "ログイン",
+        "login": "ログインする",
         "exit": "出口"
     },
     "gameDetail": {
@@ -53,16 +53,16 @@
         "timeToBeat": "ビートする時間",
         "gameModes": "ゲームモード",
         "genres": "ジャンル",
-        "gamePlatforms": "以下にも利用可能：",
+        "gamePlatforms": "また利用可能：",
         "developers": "開発者",
         "publishers": "出版社",
         "removeFromList": "削除する",
         "links": {
-            "official": "公式サイト",
+            "official": "オフィシャルサイト",
             "wikia": "ファンダム",
             "wikipedia": "ウィキペディア",
             "facebook": "フェイスブック",
-            "twitter": "Twitter",
+            "twitter": "ツイッター",
             "twitch": "けいれん",
             "instagram": "Instagram",
             "youtube": "Youtube",
@@ -100,13 +100,14 @@
         "moveRight": "右に動く",
         "emptyList": "このリストは空です",
         "addGame": "ゲームを追加",
+        "addGames": "{listName}にゲームを追加します",
         "view": "リストビュー",
         "moveList": "リストを移動する",
         "sortList": "自動ソートリスト",
         "coversSizeTitle": "全体をカバー",
         "views": {
             "single": "デフォルト",
-            "wide": "コンパクト",
+            "compact": "コンパクト",
             "text": "テキストのみ",
             "masonry": "石積み",
             "grid": "グリッド"
@@ -116,7 +117,7 @@
         "about": "約",
         "platforms": "プラットフォーム",
         "gameBoard": "ゲームボード",
-        "public": "パブリック",
+        "public": "公衆",
         "tags": "タグ",
         "account": "アカウント",
         "global": "グローバル",
@@ -132,10 +133,10 @@
             "de": "ドイツ人",
             "ar": "アラビア語",
             "fr": "フランス語",
-            "it": "イタリア語",
+            "it": "イタリアの",
             "eu": "バスク",
             "cs": "チェコ語",
-            "ja": "日本人"
+            "ja": "日本語"
         },
         "ownedLists": "プラットフォームのみを表示する",
         "sortPlatforms": "プラットフォームをアルファベット順に並べ替えます",
@@ -176,7 +177,18 @@
         "notes": "ノート"
     },
     "progresses": {
+        "modalTitle": "ゲームの進行状況を設定する",
         "addProgress": "進行状況を追加",
+        "updateProgress": "進捗状況を更新",
+        "deleteProgress": "進行状況を削除",
         "progresses": "進捗"
+    },
+    "releaseDates": {
+        "Today": "今日",
+        "ReleasesToday": "本日リリース",
+        "ReleasedToday": "本日発売",
+        "ReleasesTomorrow": "明日リリース",
+        "ReleasesInXDays": "{days}日でリリース",
+        "ToBeAnnounced": "TBA"
     }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,8 +1,8 @@
 {
     "global": {
-        "back": "Z powrotem",
+        "back": "Plecy",
         "save": "Zapisać",
-        "cancel": "anulować",
+        "cancel": "Anuluj",
         "create": "Stwórz",
         "filter": "Filtr",
         "by": "przez",
@@ -42,7 +42,7 @@
     },
     "sessionExpired": {
         "title": "Sesja wygasła",
-        "login": "Zaloguj Się",
+        "login": "Zaloguj sie",
         "exit": "Wyjście"
     },
     "gameDetail": {
@@ -88,7 +88,7 @@
         "input": "Wpisz własne",
         "add": "Dodaj listę",
         "duplicateWarning": "Masz już listę o tej nazwie",
-        "getStarted": "Zaczynać!",
+        "getStarted": "Zaczynaj!",
         "addFirstTime": "Witamy, dodaj swoją pierwszą listę!",
         "sortByName": "",
         "sortByProgress": "Postęp",
@@ -100,13 +100,14 @@
         "moveRight": "Ruch w prawo",
         "emptyList": "Ta lista jest pusta",
         "addGame": "Dodaj grę",
+        "addGames": "Dodaj gry do {listName}",
         "view": "Widok listy",
         "moveList": "Przenieś listę",
         "sortList": "Lista automatycznego sortowania",
         "coversSizeTitle": "Obejmuje w poprzek",
         "views": {
             "single": "Domyślna",
-            "wide": "Kompaktowy",
+            "compact": "Kompaktowy",
             "text": "Tylko tekst",
             "masonry": "Kamieniarstwo",
             "grid": "Krata"
@@ -121,8 +122,8 @@
         "account": "Konto",
         "global": "Światowy",
         "reloading": "Ponowne ładowanie ...",
-        "releases": "Prasowe",
-        "newsletter": "Otrzymuj e-maile z aktualizacją (wkrótce)",
+        "releases": "Wydawnictwa",
+        "newsletter": "Otrzymuj e-maile o aktualizacjach (wkrótce)",
         "branding": "Znakowanie platformy (kolory, logo itp.)",
         "language": "Język",
         "languages": {
@@ -176,7 +177,18 @@
         "notes": "Notatki"
     },
     "progresses": {
+        "modalTitle": "Ustaw postęp gry",
         "addProgress": "Dodaj postęp",
+        "updateProgress": "Postęp aktualizacji",
+        "deleteProgress": "Usuń postęp",
         "progresses": "Postęp"
+    },
+    "releaseDates": {
+        "Today": "Dzisiaj",
+        "ReleasesToday": "Wydaje dziś",
+        "ReleasedToday": "Wydany dzisiaj",
+        "ReleasesTomorrow": "Wydaje jutro",
+        "ReleasesInXDays": "Wydawnictwa za {dni} dni",
+        "ToBeAnnounced": "TBA"
     }
 }


### PR DESCRIPTION
## About
Making a wishlist is great to show the games you're interested in. But maybe the games aren't even out yet. Users will now be able to see a number of remaining days left until the release of the games. This number appears on the game card next to the existing content.

## Additional features
- text-based views show a proper text, cover based views only a number
- users can hide release days per list altogether
- users can hide game info displayed on masonry covers
- masonry lists can be sorted correctly (fixes #194)

## Screenshots
![Screenshot 2020-02-11 at 9 24 48 PM](https://user-images.githubusercontent.com/984069/74275877-fc8cec00-4d14-11ea-9f3b-3e19e592b8eb.png)
![Screenshot 2020-02-11 at 9 24 16 PM](https://user-images.githubusercontent.com/984069/74275826-e3843b00-4d14-11ea-83eb-636325e6069b.png)
![Screenshot 2020-02-11 at 9 24 53 PM](https://user-images.githubusercontent.com/984069/74275888-ff87dc80-4d14-11ea-9047-41a5033f4b91.png)
![Screenshot 2020-02-11 at 8 54 43 PM](https://user-images.githubusercontent.com/984069/74274109-d580eb00-4d11-11ea-9933-ad4cc8a23844.png)
![Screenshot 2020-02-11 at 8 55 00 PM](https://user-images.githubusercontent.com/984069/74274127-dc0f6280-4d11-11ea-8ef9-532f59f10ed1.png)
![Screenshot 2020-02-11 at 9 01 52 PM](https://user-images.githubusercontent.com/984069/74274134-df0a5300-4d11-11ea-911c-ea36e6f32dab.png)
![Screenshot 2020-02-11 at 9 02 09 PM](https://user-images.githubusercontent.com/984069/74274139-e29dda00-4d11-11ea-8a46-b9aecd6518fd.png)
