### PR TITLE
Add a Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:17-alpine AS build-env
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --verbose --frozen-lockfile
+
+COPY . ./
+RUN yarn build
+
+FROM nginx:1.27.5-alpine-slim
+WORKDIR /usr/share/nginx/html
+
+COPY --from=build-env /app/dist/ ./
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
I set up a Dockerfile that runs the app, verified locally that it works and serves site without error.

Verify this change by checking out this PR and running

```
docker build -t gamebrary-local . 
docker run --rm -p 8080:80 gamebrary-local
# open http://localhost:8080 in browser
```

I paid attention to image size, using a multi-stage build. Resulting image is only `43.3MB`.

Will leave to maintainers to build this in pipeline and release via GHCR or similar.